### PR TITLE
updated FRD2RAW.py

### DIFF
--- a/FRD2RAW.py
+++ b/FRD2RAW.py
@@ -1,12 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-# example: cmsRun FRD2RAW.py inputFiles=file:fedraw1.raw,file:fedraw2.raw [outputFile=output.root] [run=0] [firstLS=1] [maxEvents=-1]
+# example: cmsRun FRD2RAW.py inputFiles=file:fedraw1.raw,file:fedraw2.raw [outputFile=output.root] [firstRun=0] [firstLS=1] [maxEvents=-1]
 
 process = cms.Process('LHC')
 
 import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing ('analysis') 
-options.register('run', 0, options.multiplicity.singleton, options.varType.int, 'run number (passed to process.source.firstRun)')
+options.register('firstRun', 0, options.multiplicity.singleton, options.varType.int, 'value passed to process.source.firstRun')
 options.register('firstLS', 1, options.multiplicity.singleton, options.varType.int, 'first luminosity block for selected run')
 options.parseArguments()
 
@@ -19,8 +19,8 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source('ErrorStreamSource',
   fileNames = cms.untracked.vstring(options.inputFiles),
-  firstRun = cms.untracked.uint32(options.run),
-  firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID(*[cms.LuminosityBlockID(options.firstLS, options.run)]),
+  firstRun = cms.untracked.uint32(options.firstRun),
+  firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID(*[cms.LuminosityBlockID(options.firstLS, options.firstRun)]),
 )
 
 from EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi import rawDataCollector

--- a/FRD2RAW.py
+++ b/FRD2RAW.py
@@ -1,37 +1,40 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("LHC")
+# example: cmsRun FRD2RAW.py inputFiles=file:fedraw1.raw,file:fedraw2.raw [outputFile=output.root] [run=0] [firstLS=1] [maxEvents=-1]
 
+process = cms.Process('LHC')
 
 import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing ('analysis') 
-options.register('firstRun',0,options.multiplicity.singleton,options.varType.int,"pass to firstRun")
+options.register('run', 0, options.multiplicity.singleton, options.varType.int, 'run number (passed to process.source.firstRun)')
+options.register('firstLS', 1, options.multiplicity.singleton, options.varType.int, 'first luminosity block for selected run')
 options.parseArguments()
 
+if len(options.inputFiles) == 0:
+   raise RuntimeError('empty list of input files (use "inputFiles=..")')
+
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+  input = cms.untracked.int32(options.maxEvents)
 )
 
-process.source = cms.Source("ErrorStreamSource",
-#                            fileNames = cms.untracked.vstring("/store/error_stream/run320917/run320917_ls0149_index000167_fu-c2d44-34-03_pid22180.raw"),
-                            fileNames = cms.untracked.vstring(options.inputFiles),
-                            firstRun  = cms.untracked.uint32(options.firstRun)
-                            )
-
+process.source = cms.Source('ErrorStreamSource',
+  fileNames = cms.untracked.vstring(options.inputFiles),
+  firstRun = cms.untracked.uint32(options.run),
+  firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID(*[cms.LuminosityBlockID(options.firstLS, options.run)]),
+)
 
 from EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi import rawDataCollector
 process.rawDataCollector = rawDataCollector.clone(
-        verbose = cms.untracked.int32(0),
-            RawCollectionList = cms.VInputTag( cms.InputTag('source') )
-        )
+  verbose = cms.untracked.int32(0),
+  RawCollectionList = cms.VInputTag(cms.InputTag('source'))
+)
 
-process.output = cms.OutputModule( "PoolOutputModule",
-#                                   fileName = cms.untracked.string( "file:/cmsnfshltdata/hltdata/TSG/ErrorStream/test.root" ),
-                                   fileName = cms.untracked.string(options.outputFile ),
-                                   outputCommands = cms.untracked.vstring(
-                                                                          'drop *',
-                                                                          'keep *_rawDataCollector_*_*'
-                                   )
+process.output = cms.OutputModule('PoolOutputModule',
+  fileName = cms.untracked.string(options.outputFile),
+  outputCommands = cms.untracked.vstring(
+    'drop *',
+    'keep *_rawDataCollector_*_*',
+  ),
 )
 
 process.raw = cms.Path( process.rawDataCollector )


### PR DESCRIPTION
* small updates to `FRD2RAW.py`
  - when testing with a recent release, the script needed to be updated to specify
    `process.source.firstLuminosityBlockForEachRun` (similarly to what was done [here](https://github.com/cms-sw/cmssw/commit/b8753611f49f8096666578ef3a7b9afea66e2678); the latter refers to `11_X`, but this update is already necessary to run `FRD2RAW.py` in recent `10_6_X`)

* tested with recent error-stream data, in `10_6_8_patch1`

* part of the changes are just code-formatting