### PR TITLE
updates from 2020's MWGR#1

### DIFF
--- a/genTestFakeBuFromRAW_cfg.py
+++ b/genTestFakeBuFromRAW_cfg.py
@@ -22,6 +22,10 @@ cmsswbase = os.path.expandvars('$CMSSW_BASE/')
 
 fileNamesByRun_dict = {
 
+  334518 : [ # 2020 MWGR0 / VirginRaw
+    '/store/data/Commissioning2019/VRRandom3/RAW/v1/000/334/518/00000/18B41CEB-DCF7-BD46-B6BC-0E7E56E7B047.root',
+  ],
+
   334393 : [ # 2020 MWGR0 / Cosmics
     '/store/data/Commissioning2019/HLTPhysics/RAW/v1/000/334/393/00000/E0D10C28-5C45-8147-A967-8FCE150D9514.root',
   ],

--- a/genTestFakeBuFromRAW_cfg.py
+++ b/genTestFakeBuFromRAW_cfg.py
@@ -233,21 +233,35 @@ process.source = cms.Source("PoolSource",
   skipEvents = cms.untracked.uint32(0),
 )
 
-process.EvFDaqDirector = cms.Service("EvFDaqDirector",
-                                     runNumber= cms.untracked.uint32(options.runNumber),
-                                     baseDir = cms.untracked.string(options.dataDir),
-                                     buBaseDir = cms.untracked.string("/fff/BU0/data"),
-                                     directorIsBu = cms.untracked.bool(True),
-                                     #obsolete:
-                                     hltBaseDir = cms.untracked.string("/fff/BU0/ramdisk"),
-                                     smBaseDir  = cms.untracked.string("/fff/BU0/ramdisk"),
-                                     slaveResources = cms.untracked.vstring('dvfu-c2f37-38-01'),
-                                     slavePathToData = cms.untracked.string("/fff/BU/ramdisk")
+def isPreCMSSW11():
+   try:
+      import os
+      return int(os.environ['CMSSW_VERSION'].split("_")[1])<11
+   except:
+      print "error trying to get CMSSW version, assuming version >=11"
+      return False
+
+if isPreCMSSW11():
+   print "setting up DAQ director for CMSSW versions <11"
+   process.EvFDaqDirector = cms.Service("EvFDaqDirector",
+                                        runNumber= cms.untracked.uint32(options.runNumber),
+                                        baseDir = cms.untracked.string(options.dataDir),
+                                        buBaseDir = cms.untracked.string("/fff/BU0/data"),
+                                        directorIsBu = cms.untracked.bool(True),
+                                        #obsolete:
+                                        hltBaseDir = cms.untracked.string("/fff/BU0/ramdisk"),
+                                        smBaseDir  = cms.untracked.string("/fff/BU0/ramdisk"),
+                                        slaveResources = cms.untracked.vstring('dvfu-c2f37-38-01'),
+                                        slavePathToData = cms.untracked.string("/fff/BU/ramdisk")
                                      )
-#process.EvFBuildingThrottle = cms.Service("EvFBuildingThrottle",
-#                                          highWaterMark = cms.untracked.double(0.90),
-#                                          lowWaterMark = cms.untracked.double(0.45)
-#                                          )
+else:
+   print "setting up DAQ director for CMSSW versions >=11"
+   process.EvFDaqDirector = cms.Service("EvFDaqDirector",
+                                        runNumber= cms.untracked.uint32(options.runNumber),
+                                        baseDir = cms.untracked.string(options.dataDir),
+                                        buBaseDir = cms.untracked.string("/fff/BU0/data"),
+                                        directorIsBU = cms.untracked.bool(True),
+                                     )
 
 process.a = cms.EDAnalyzer("ExceptionGenerator",
                            defaultAction = cms.untracked.int32(0),

--- a/genTestFakeBuFromRAW_cfg.py
+++ b/genTestFakeBuFromRAW_cfg.py
@@ -22,11 +22,15 @@ cmsswbase = os.path.expandvars('$CMSSW_BASE/')
 
 fileNamesByRun_dict = {
 
-  331595 : [ # MWGR4 / VirginRaw
+  334393 : [ # 2020 MWGR0 / Cosmics
+    '/store/data/Commissioning2019/HLTPhysics/RAW/v1/000/334/393/00000/E0D10C28-5C45-8147-A967-8FCE150D9514.root',
+  ],
+
+  331595 : [ # 2019 MWGR4 / VirginRaw
     '/store/data/Commissioning2019/VRRandom3/RAW/v1/000/331/595/00000/3F49019E-7FA1-9A41-A8DE-418E5AEB988E.root',
   ],
 
-  331483 : [ # MWGR4 / Cosmics
+  331483 : [ # 2019 MWGR4 / Cosmics
     '/store/data/Commissioning2019/HLTPhysics/RAW/v1/000/331/483/00000/26C27254-3211-3942-B192-AFC3DB02BF1D.root',
   ],
 

--- a/runFastTrackValidation.sh
+++ b/runFastTrackValidation.sh
@@ -19,14 +19,14 @@ sleep 5
 ######### user params #########
 
 # Cosmics
-testMenu=/cdaq/special/2019/MWGR1/CruzetForMWGR1/HLT/V9
+testMenu=/cdaq/special/2020/MWGR1/CruzetForMWGR1/HLT/V10
 runNumber=334393
-testGT=110X_dataRun3_HLT_HcalForMWGR1_v1
+testGT=110X_dataRun3_HLT_v1
 
 # # VirginRaw
-# testMenu=/cdaq/special/2019/MWGR1/VirginRaw/VR_Random_TS2/HLT/V6
-# runNumber=331595
-# testGT=106X_dataRun3_HLT_v4
+# testMenu=/cdaq/special/2020/MWGR1/VirginRaw/VR_Random_TS2/HLT/V9
+# runNumber=334518
+# testGT=110X_dataRun3_HLT_v1
 
 ###############################
 

--- a/runFastTrackValidation.sh
+++ b/runFastTrackValidation.sh
@@ -20,8 +20,8 @@ sleep 5
 
 # Cosmics
 testMenu=/cdaq/special/2019/MWGR1/CruzetForMWGR1/HLT/V9
-runNumber=331483
-testGT=106X_dataRun3_HLT_v4
+runNumber=334393
+testGT=110X_dataRun3_HLT_HcalForMWGR1_v1
 
 # # VirginRaw
 # testMenu=/cdaq/special/2019/MWGR1/VirginRaw/VR_Random_TS2/HLT/V6

--- a/setup.sh
+++ b/setup.sh
@@ -12,8 +12,8 @@ export http_proxy="http://cmsproxy.cms:3128/"
 export https_proxy="https://cmsproxy.cms:3128/"
 export NO_PROXY=".cms,localhost"
 #export SCRAM_ARCH=slc7_amd64_gcc630
-export SCRAM_ARCH=slc7_amd64_gcc700
-#export SCRAM_ARCH=slc7_amd64_gcc820
+#export SCRAM_ARCH=slc7_amd64_gcc700
+export SCRAM_ARCH=slc7_amd64_gcc820
 #source /opt/hilton/cmssw/cmsset_default.sh
 source /opt/offline/cmsset_default.sh
 


### PR DESCRIPTION
* updates developed during 2020's MWGR#1 (first global-run with `CMSSW_11`)

* the commit message in ce6dba8 is wrong (should `MWGR1` instead of `MWGR0`)

@Sam-Harper